### PR TITLE
Add SongDocumentService for Elasticsearch operations

### DIFF
--- a/src/main/java/com/example/song_be/domain/song/service/SongDocumentService.java
+++ b/src/main/java/com/example/song_be/domain/song/service/SongDocumentService.java
@@ -1,0 +1,16 @@
+package com.example.song_be.domain.song.service;
+
+import com.example.song_be.domain.song.document.SongDocument;
+
+import java.util.Optional;
+
+public interface SongDocumentService {
+
+    Iterable<SongDocument> findAll();
+
+    Optional<SongDocument> findById(Long id);
+
+    SongDocument save(SongDocument document);
+
+    void deleteById(Long id);
+}

--- a/src/main/java/com/example/song_be/domain/song/service/SongDocumentServiceImpl.java
+++ b/src/main/java/com/example/song_be/domain/song/service/SongDocumentServiceImpl.java
@@ -1,0 +1,39 @@
+package com.example.song_be.domain.song.service;
+
+import com.example.song_be.domain.song.document.SongDocument;
+import com.example.song_be.domain.song.repository.SongSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SongDocumentServiceImpl implements SongDocumentService {
+
+    private final SongSearchRepository songSearchRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Iterable<SongDocument> findAll() {
+        return songSearchRepository.findAll();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<SongDocument> findById(Long id) {
+        return songSearchRepository.findById(id);
+    }
+
+    @Override
+    public SongDocument save(SongDocument document) {
+        return songSearchRepository.save(document);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        songSearchRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/example/song_be/domain/song/service/SongServiceImpl.java
+++ b/src/main/java/com/example/song_be/domain/song/service/SongServiceImpl.java
@@ -4,7 +4,7 @@ import com.example.song_be.domain.song.dto.SongDTO;
 import com.example.song_be.domain.song.entity.Song;
 import com.example.song_be.domain.song.document.SongDocument;
 import com.example.song_be.domain.song.repository.SongRepository;
-import com.example.song_be.domain.song.repository.SongSearchRepository;
+import com.example.song_be.domain.song.service.SongDocumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,14 +20,14 @@ import java.util.stream.StreamSupport;
 public class SongServiceImpl implements SongService {
 
     private final SongRepository songRepository;
-    private final SongSearchRepository songSearchRepository;
+    private final SongDocumentService songDocumentService;
 
     @Override
     @Transactional(readOnly = true)
     public List<SongDTO> getSongList() {
         log.info("getSongList start...");
 
-        Iterable<SongDocument> docs = songSearchRepository.findAll();
+        Iterable<SongDocument> docs = songDocumentService.findAll();
         return StreamSupport.stream(docs.spliterator(), false)
                 .map(this::toDTO)
                 .toList();
@@ -38,7 +38,7 @@ public class SongServiceImpl implements SongService {
     public SongDTO getSongById(Long id) {
         log.info("getSongById start...");
 
-        return songSearchRepository.findById(id)
+        return songDocumentService.findById(id)
                 .map(this::toDTO)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 곡이 없습니다: " + id));
     }
@@ -48,7 +48,7 @@ public class SongServiceImpl implements SongService {
         log.info("createSong start...");
 
         Song saved = songRepository.save(toEntity(songDTO));
-        songSearchRepository.save(toDocument(saved));
+        songDocumentService.save(toDocument(saved));
         return toDTO(saved);
     }
 
@@ -67,13 +67,13 @@ public class SongServiceImpl implements SongService {
         song.setLyrics_original(songDTO.getLyrics_original());
         song.setLyrics_kr(songDTO.getLyrics_kr());
 
-        songSearchRepository.save(toDocument(song));
+        songDocumentService.save(toDocument(song));
         return toDTO(song);
     }
 
     @Override
     public void deleteSong(Long id) {
         songRepository.deleteById(id);
-        songSearchRepository.deleteById(id);
+        songDocumentService.deleteById(id);
     }
 }


### PR DESCRIPTION
## Summary
- create `SongDocumentService` interface
- implement `SongDocumentServiceImpl`
- update `SongServiceImpl` to use the new Elasticsearch service

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684fd201c55c832eacf2133efaaf9e74