### PR TITLE
Separate Elastic search from SongService

### DIFF
--- a/src/main/java/com/example/song_be/domain/song/controller/SongSearchController.java
+++ b/src/main/java/com/example/song_be/domain/song/controller/SongSearchController.java
@@ -1,0 +1,52 @@
+package com.example.song_be.domain.song.controller;
+
+import com.example.song_be.domain.song.document.SongDocument;
+import com.example.song_be.domain.song.dto.SongDTO;
+import com.example.song_be.domain.song.service.SongDocumentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+@RestController
+@RequestMapping("/api/es/song")
+@RequiredArgsConstructor
+@Slf4j
+public class SongSearchController {
+
+    private final SongDocumentService songDocumentService;
+
+    @GetMapping("/list")
+    public List<SongDTO> getSongs() {
+        Iterable<SongDocument> docs = songDocumentService.findAll();
+        return StreamSupport.stream(docs.spliterator(), false)
+                .map(this::toDTO)
+                .toList();
+    }
+
+    @GetMapping("/{id}")
+    public SongDTO getSong(@PathVariable Long id) {
+        return songDocumentService.findById(id)
+                .map(this::toDTO)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 곡이 없습니다: " + id));
+    }
+
+    private SongDTO toDTO(SongDocument document) {
+        return SongDTO.builder()
+                .songId(document.getSongId())
+                .tj_number(document.getTj_number())
+                .ky_number(document.getKy_number())
+                .title_kr(document.getTitle_kr())
+                .title_en(document.getTitle_en())
+                .title_jp(document.getTitle_jp())
+                .title_yomi(document.getTitle_yomi())
+                .lang(document.getLang())
+                .artist(document.getArtist())
+                .artist_kr(document.getArtist_kr())
+                .lyrics_original(document.getLyrics_original())
+                .lyrics_kr(document.getLyrics_kr())
+                .build();
+    }
+}

--- a/src/main/java/com/example/song_be/domain/song/service/SongServiceImpl.java
+++ b/src/main/java/com/example/song_be/domain/song/service/SongServiceImpl.java
@@ -2,16 +2,13 @@ package com.example.song_be.domain.song.service;
 
 import com.example.song_be.domain.song.dto.SongDTO;
 import com.example.song_be.domain.song.entity.Song;
-import com.example.song_be.domain.song.document.SongDocument;
 import com.example.song_be.domain.song.repository.SongRepository;
-import com.example.song_be.domain.song.service.SongDocumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.StreamSupport;
 
 @Slf4j
 @Transactional
@@ -20,15 +17,13 @@ import java.util.stream.StreamSupport;
 public class SongServiceImpl implements SongService {
 
     private final SongRepository songRepository;
-    private final SongDocumentService songDocumentService;
 
     @Override
     @Transactional(readOnly = true)
     public List<SongDTO> getSongList() {
         log.info("getSongList start...");
 
-        Iterable<SongDocument> docs = songDocumentService.findAll();
-        return StreamSupport.stream(docs.spliterator(), false)
+        return songRepository.findAll().stream()
                 .map(this::toDTO)
                 .toList();
     }
@@ -38,7 +33,7 @@ public class SongServiceImpl implements SongService {
     public SongDTO getSongById(Long id) {
         log.info("getSongById start...");
 
-        return songDocumentService.findById(id)
+        return songRepository.findById(id)
                 .map(this::toDTO)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 곡이 없습니다: " + id));
     }
@@ -48,7 +43,6 @@ public class SongServiceImpl implements SongService {
         log.info("createSong start...");
 
         Song saved = songRepository.save(toEntity(songDTO));
-        songDocumentService.save(toDocument(saved));
         return toDTO(saved);
     }
 
@@ -66,14 +60,12 @@ public class SongServiceImpl implements SongService {
         song.setArtist_kr(songDTO.getArtist_kr());
         song.setLyrics_original(songDTO.getLyrics_original());
         song.setLyrics_kr(songDTO.getLyrics_kr());
-
-        songDocumentService.save(toDocument(song));
+        songRepository.save(song);
         return toDTO(song);
     }
 
     @Override
     public void deleteSong(Long id) {
         songRepository.deleteById(id);
-        songDocumentService.deleteById(id);
     }
 }


### PR DESCRIPTION
## Summary
- remove `SongDocumentService` usage from `SongServiceImpl`
- add dedicated `SongSearchController` for Elasticsearch access

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6dda5cc832e92f88d19699a9016